### PR TITLE
fix 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(a6000_ros)
 
-
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_FLAGS "-Wall") # we should be warning free
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
 
 find_package(Gphoto2 REQUIRED) # camera driver base
@@ -38,13 +38,10 @@ file(GLOB src_dir
 
 message(STATUS ${PROJECT_SOURCE_DIR})
 
-# set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ../)
-
 # test exe, independent of ROS
 add_executable(${PROJECT_NAME}_test ${src_dir} src/test/main.cpp)
 target_include_directories(${PROJECT_NAME}_test PUBLIC  ${PROJECT_SOURCE_DIR}/include ${Gphoto2_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}_test PRIVATE ${Gphoto2_LIBRARIES})
-
 
 # the main ros driver
 add_executable(${PROJECT_NAME}_node ${src_dir} src/ros/camera_node.cpp src/ros/camera_ros.cpp)

--- a/include/camera_connector.h
+++ b/include/camera_connector.h
@@ -50,6 +50,18 @@ public:
 
     bool isConnected();
 
+    /** Capture an image off the camera, and store it on memory.
+     * image_data will the image as a byte array (in the case of the a6000,
+     * this data array is fully in a jpeg format). Size will return with the 
+     * corresponding size of the image.
+     * 
+     * NOTE: This method assumes serial operation. ie: capture one image, process
+     *  it and then capture another image, without ever needing to reference the 
+     *  previous image again. It is the responsibility of the user to memcopy
+     *  the buffer if they want to access an old image after calling this function
+     *  a second time.
+     * 
+     */
     bool captureImage(const char** image_data, unsigned long* size);
 
     bool lastImageHasEXIF();
@@ -113,6 +125,7 @@ private:
 
     GPContext* context = nullptr;
     Camera *camera = nullptr;
+    CameraFile *currentFile_ = nullptr;
     easyexif::EXIFInfo exifInfo;
     bool connected_;
     bool autoReconnect_ = true;

--- a/include/gphoto_drv.h
+++ b/include/gphoto_drv.h
@@ -16,7 +16,7 @@ void printCameraPortInfo(Camera* camera);
 int capture_to_memory(Camera *camera, GPContext *context, const char **ptr, unsigned long int *size);
 // more robust than capture_to_memory. Will continuously trigger a shot until the camera does a successful capture and
 // we pull it off the camera
-int trigger_capture_to_memory(GPContext *context, Camera *camera, const char** data, unsigned long int *size);
+int trigger_capture_to_memory(GPContext *context, Camera *camera, CameraFile* file, const char** data, unsigned long int *size);
 
 //config gettter functions:
 float get_config_value_float(GPContext *context, Camera *camera, const char *key);

--- a/src/driver/trigger_capture.c
+++ b/src/driver/trigger_capture.c
@@ -56,7 +56,6 @@ static int wait_event_and_download(GPContext *context, Camera *camera, int waitt
 		}
 	}
 	if (got_path_) {
-
 		retval = gp_file_new(&file);
 
 		printf("   camera getfile of %s\n", path_->name);
@@ -77,7 +76,6 @@ static int wait_event_and_download(GPContext *context, Camera *camera, int waitt
 		}
 
 		retval = gp_camera_file_delete(camera, path_->folder, path_->name, context);
-		// gp_file_free(file); 
 		free(data);
 		captured = 1;
 	}

--- a/src/driver/trigger_capture.c
+++ b/src/driver/trigger_capture.c
@@ -15,7 +15,7 @@ static int captured;
  * This code comes from libgphoto2's samples, with some modification done by me
  * waittime in ms?
  */
-static int wait_event_and_download(GPContext *context, Camera *camera, int waittime, const char **buffer, unsigned long int *size) {
+static int wait_event_and_download(GPContext *context, Camera *camera, int waittime, CameraFile* file, const char **buffer, unsigned long int *size) {
 	CameraEventType	evtype;
 	CameraFilePath	*path_;
 	void			*data;
@@ -56,7 +56,6 @@ static int wait_event_and_download(GPContext *context, Camera *camera, int waitt
 		}
 	}
 	if (got_path_) {
-		CameraFile	*file;
 
 		retval = gp_file_new(&file);
 
@@ -78,14 +77,14 @@ static int wait_event_and_download(GPContext *context, Camera *camera, int waitt
 		}
 
 		retval = gp_camera_file_delete(camera, path_->folder, path_->name, context);
-		gp_file_free(file);
+		// gp_file_free(file); 
 		free(data);
 		captured = 1;
 	}
 	return GP_OK;
 }
 
-int trigger_capture_to_memory(GPContext *context, Camera *camera, const char** data, unsigned long* size) {
+int trigger_capture_to_memory(GPContext *context, Camera *camera, CameraFile* file, const char** data, unsigned long* size) {
 	int		retval;
 	captured = 0;
 
@@ -95,7 +94,7 @@ int trigger_capture_to_memory(GPContext *context, Camera *camera, const char** d
 		return retval;
 	}
 	while (!captured) {
-		retval = wait_event_and_download(context, camera, 100, data, size);
+		retval = wait_event_and_download(context, camera, 100, file, data, size);
 		if (captured || retval != GP_OK) {
 			break;
 		}

--- a/src/ros/camera_ros.cpp
+++ b/src/ros/camera_ros.cpp
@@ -87,7 +87,6 @@ void GphotoCameraROS::run() {
     }
 
     // make sure to properly detach camera resources!
-    printf("Call close...\n");
     cam_.close();
 }
 

--- a/src/ros/camera_ros.cpp
+++ b/src/ros/camera_ros.cpp
@@ -87,6 +87,7 @@ void GphotoCameraROS::run() {
     }
 
     // make sure to properly detach camera resources!
+    printf("Call close...\n");
     cam_.close();
 }
 


### PR DESCRIPTION
fixes seg fault described in #8 

Code somehow worked earlier (against all logic). gp_file_free, makes frees the buffer holding the jpg file locally, thus invalidating any pointers to it. I was freeing the file immediately after I grabbed it. This was risky since that memory could become anything, and just straight up didn't work on the plane's odroid.